### PR TITLE
Handle package files that failed to download

### DIFF
--- a/cmake-d/UseDub.cmake
+++ b/cmake-d/UseDub.cmake
@@ -50,7 +50,13 @@ include(ExternalProject)
 
 function(DubProject_Add name)
 	if(NOT EXISTS ${DUB_DIRECTORY}/${name}.json)
-		file(DOWNLOAD ${DUB_REGISTRY}/${name}.json ${DUB_DIRECTORY}/${name}.json)
+		file(DOWNLOAD ${DUB_REGISTRY}/${name}.json ${DUB_DIRECTORY}/${name}.json STATUS status)
+		list(GET status 0 statusCode)
+		
+		if(NOT statusCode EQUAL 0)
+			file(REMOVE ${DUB_DIRECTORY}/${name}.json)
+			message(FATAL_ERROR "Failed to download ${DUB_REGISTRY}/${name}.json")
+		endif(NOT statusCode EQUAL 0)
 	endif(NOT EXISTS ${DUB_DIRECTORY}/${name}.json)
 
 	if(${ARGC} GREATER 1)


### PR DESCRIPTION
Awesome work on this stuff, @dcarp. I integrated it in one of my projects, this was the only issue I ran in to. Also, shouldn't there be a link_directories command somewhere, or did you intentionally leave that up to the user for e.g. optlink sillyness? 
