### PR TITLE
Fix capitalization of UseDub.cmake in CMakeLists.txt

### DIFF
--- a/cmake-d/CMakeLists.txt
+++ b/cmake-d/CMakeLists.txt
@@ -22,7 +22,7 @@ SET (MOD_SRCS
 	FindGDCPath.cmake
 	UseDDoc.cmake
 	UseDDeps.cmake
-	UseDUB.cmake
+	UseDub.cmake
 	dependencies.cmake
 	UseDUnittest.cmake
 	FindPhobos.cmake


### PR DESCRIPTION
Small error in capitalization causes install to fail (on linux).
